### PR TITLE
Add lucycontoso1 as project collaborator

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# These owners will be the default owners for everything in the repo
+* @AdrianContoso @lucycontoso1
+
+# Specific ownership for adoption-related files
+/src/main/java/org/springframework/samples/petclinic/adoption/ @lucycontoso1


### PR DESCRIPTION
This PR adds lucycontoso1 as a collaborator to the project by:
1. Adding a CODEOWNERS file
2. Giving specific ownership of the adoption-related features
3. Adding as a co-owner of the entire repository

Please review and merge to grant access.